### PR TITLE
Support (configurable) user approval/denial of MCP tool-use requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.pyc
 .specstory
 .mypy_cache
+.cursor
 .cursorrules
 .repomix-output.txt
 repomix-output.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-responses-python-quickstart"
-version = "1.3.0"
+version = "1.4.0"
 description = "A quickstart template using the OpenAI Assistants API with Python, FastAPI, Jinja2, and HTMX"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/routers/chat.py
+++ b/routers/chat.py
@@ -192,7 +192,6 @@ async def stream_response(
                                     )
 
                             case ResponseOutputItemAddedEvent():
-                                logger.info(f"ResponseOutputItemAddedEvent: {event}")
                                 # Skip reasoning steps by default (later make this configurable and/or mount a thinking indicator)
                                 if event.item.id and event.item.type in ["message", "output_text"]:
                                     current_item_id = event.item.id
@@ -220,7 +219,6 @@ async def stream_response(
                                     tool_name = event.item.name
                                     # Skip if TOOL_CONFIG.mcp_servers item with same server_label has require_approval set to
                                     # "always", as approval form provides adequate notification to the user of the tool call
-                                    logger.info(f"TOOL_CONFIG.mcp_servers: {TOOL_CONFIG.mcp_servers}")
                                     if any(
                                         server["server_label"] == server_label and server["require_approval"] == "always"
                                         for server in TOOL_CONFIG.mcp_servers
@@ -236,7 +234,6 @@ async def stream_response(
                                     )
                                 # Handle MCP approval requests by rendering an approval UI card
                                 if isinstance(event.item, McpApprovalRequest):
-                                    logger.info(f"MCP approval request: {event.item}")
                                     current_item_id = event.item.id
                                     # Pretty print arguments JSON if possible
                                     pretty_args: str
@@ -411,9 +408,6 @@ async def approve_mcp_tool(
 ) -> HTMLResponse:
     # Create an approval response conversation item
     try:
-        # Debug by getting conversation items and logging approval request
-        items = await client.conversations.items.list(conversation_id=conversation_id)
-        logger.info(f"Conversation items: {items}")
         await client.conversations.items.create(
             conversation_id=conversation_id,
             items=[{

--- a/routers/chat.py
+++ b/routers/chat.py
@@ -23,6 +23,8 @@ from openai.types.responses import (
     ResponseMcpCallArgumentsDoneEvent, ResponseMcpCallCompletedEvent,
     ResponseMcpCallInProgressEvent, ResponseMcpCallArgumentsDeltaEvent
 )
+from openai.types.responses.response_output_item import McpApprovalRequest
+from openai.types.responses import ResponseFunctionToolCall
 from openai._types import NOT_GIVEN
 from openai import AsyncOpenAI
 from utils.function_calling import Context, FunctionResult
@@ -150,7 +152,6 @@ async def stream_response(
             try:
                 async with s as events:
                     async for event in events:
-                        logger.info(f"Event: {event}")
                         match event:
                             case ResponseCreatedEvent():
                                 response_id = event.response.id
@@ -180,6 +181,7 @@ async def stream_response(
                             case ResponseFileSearchCallSearchingEvent() | ResponseCodeInterpreterCallInProgressEvent():
                                 tool = event.type.split(".")[1].split("_call")[0]
                                 current_item_id = event.item_id
+                                # Skip if 
                                 yield sse_format(
                                         "toolCallCreated",
                                         templates.get_template('components/assistant-step.html').render(
@@ -190,6 +192,7 @@ async def stream_response(
                                     )
 
                             case ResponseOutputItemAddedEvent():
+                                logger.info(f"ResponseOutputItemAddedEvent: {event}")
                                 # Skip reasoning steps by default (later make this configurable and/or mount a thinking indicator)
                                 if event.item.id and event.item.type in ["message", "output_text"]:
                                     current_item_id = event.item.id
@@ -200,9 +203,7 @@ async def stream_response(
                                             step_id=event.item.id
                                         )
                                     )
-                                if event.item.type in [
-                                    "function_call", "mcp_call"
-                                ]:
+                                if event.item.type == "function_call":
                                     current_item_id = event.item.id
                                     tool_name = event.item.name
                                     yield sse_format(
@@ -211,6 +212,50 @@ async def stream_response(
                                             step_type='toolCall',
                                             step_id=event.item.id,
                                             content=f"Calling {tool_name} tool..." + ("\n" if show_tool_call_detail else "")
+                                        )
+                                    )
+                                if event.item.type == "mcp_call":
+                                    current_item_id = event.item.id
+                                    server_label = event.item.server_label
+                                    tool_name = event.item.name
+                                    # Skip if TOOL_CONFIG.mcp_servers item with same server_label has require_approval set to
+                                    # "always", as approval form provides adequate notification to the user of the tool call
+                                    logger.info(f"TOOL_CONFIG.mcp_servers: {TOOL_CONFIG.mcp_servers}")
+                                    if any(
+                                        server.server_label == server_label and server.require_approval == "always"
+                                        for server in TOOL_CONFIG.mcp_servers
+                                    ):
+                                        continue
+                                    yield sse_format(
+                                        "toolCallCreated",
+                                        templates.get_template('components/assistant-step.html').render(
+                                            step_type='toolCall',
+                                            step_id=event.item.id,
+                                            content=f"Calling {tool_name} tool..." + ("\n" if show_tool_call_detail else "")
+                                        )
+                                    )
+                                # Handle MCP approval requests by rendering an approval UI card
+                                if isinstance(event.item, McpApprovalRequest):
+                                    logger.info(f"MCP approval request: {event.item}")
+                                    current_item_id = event.item.id
+                                    # Pretty print arguments JSON if possible
+                                    pretty_args: str
+                                    try:
+                                        pretty_args = json.dumps(json.loads(event.item.arguments), indent=2)
+                                    except Exception:
+                                        pretty_args = event.item.arguments
+
+                                    approval_card_html = templates.get_template("components/mcp-approval-request.html").render(
+                                        conversation_id=conversation_id,
+                                        approval_request=event.item,
+                                        arguments_pretty=pretty_args
+                                    )
+                                    yield sse_format(
+                                        "mcpApprovalRequest",
+                                        templates.get_template('components/assistant-step.html').render(
+                                            step_type='approvalRequest',
+                                            step_id=event.item.id,
+                                            content_html=approval_card_html
                                         )
                                     )
 
@@ -223,7 +268,6 @@ async def stream_response(
                                     yield sse_format("textDelta", wrap_for_oob_swap(current_item_id, event.delta))
 
                             case ResponseOutputTextAnnotationAddedEvent():
-                                logger.info(f"ResponseOutputTextAnnotationAddedEvent: {event}")
                                 if event.annotation and current_item_id:
                                     if event.annotation["type"] == "file_citation":
                                         filename = event.annotation["filename"]
@@ -254,7 +298,7 @@ async def stream_response(
                                     yield sse_format("toolDelta", wrap_for_oob_swap(current_item_id, str(delta)))
 
                             case ResponseOutputItemDoneEvent():
-                                if event.item.type == "function_call":
+                                if isinstance(event.item, ResponseFunctionToolCall):
                                     current_item_id = event.item.id
                                     function_name = event.item.name
                                     arguments_json = json.loads(event.item.arguments)
@@ -337,3 +381,45 @@ async def stream_response(
             "Connection": "keep-alive",
         }
     )
+
+
+@router.post("/approve")
+async def approve_mcp_tool(
+    request: Request,
+    conversation_id: str,
+    approval_request_id: str = Form(...),
+    approve: bool = Form(...),
+    reason: str | None = Form(None),
+    client: AsyncOpenAI = Depends(lambda: AsyncOpenAI())
+) -> HTMLResponse:
+    # Create an approval response conversation item
+    try:
+        # Debug by getting conversation items and logging approval request
+        items = await client.conversations.items.list(conversation_id=conversation_id)
+        logger.info(f"Conversation items: {items}")
+        await client.conversations.items.create(
+            conversation_id=conversation_id,
+            items=[{
+                "type": "mcp_approval_response",
+                "approval_request_id": approval_request_id,
+                "approve": approve,
+                **({"reason": reason} if reason else {})
+            }]
+        )
+    except Exception as e:
+        logger.error(f"Failed to submit MCP approval response: {e}")
+        # Render a minimal error card and allow retry
+        error_html = f"<div class=\"assistantMessage\">Error submitting approval: {str(e)}</div>"
+        return HTMLResponse(content=error_html)
+
+    # After approval decision, start a new stream run by returning a new assistant-run include
+    assistant_run_html = templates.get_template("components/assistant-run.html").render(
+        request=request, conversation_id=conversation_id
+    )
+    # Also append a small acknowledgement step
+    ack_html = templates.get_template("components/assistant-step.html").render(
+        step_type="systemNote",
+        step_id=f"ack-{approval_request_id}",
+        content=("Approved MCP tool request" if approve else "Rejected MCP tool request") + (f": {reason}" if reason else "")
+    )
+    return HTMLResponse(content=(ack_html + assistant_run_html))

--- a/routers/setup.py
+++ b/routers/setup.py
@@ -94,6 +94,18 @@ async def read_setup(
             **({"connector_id": srv["connector_id"]} if "connector_id" in srv else {}),
             **({"authorization": srv["authorization"]} if "authorization" in srv else {}),
         }
+        # Normalize require_approval to a simple string always/never for the UI
+        try:
+            if "require_approval" in srv:
+                ra = srv.get("require_approval")
+                if isinstance(ra, str):
+                    entry["require_approval"] = "always" if ra.lower() == "always" else "never"
+                elif isinstance(ra, dict):
+                    entry["require_approval"] = "always" if "always" in ra else "never"
+            else:
+                entry["require_approval"] = "never"
+        except Exception:
+            entry["require_approval"] = "never"
         if "headers" in srv and isinstance(srv["headers"], dict):
             try:
                 entry["headers_json"] = json.dumps(srv["headers"]) or ""

--- a/static/styles.css
+++ b/static/styles.css
@@ -456,6 +456,21 @@ pre {
   background-color: #efefef;
 }
 
+/* MCP approval UI spacing */
+.approvalCard { margin: 10px 0; padding: 8px 10px; border-radius: 8px; background: #f7f7f7; }
+.approvalHeader { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.approvalMeta { display: flex; align-items: center; gap: 12px; font-size: 1em; color: #444; }
+.approvalMeta code { font-size: 1em; }
+@media (max-width: 600px) {
+  .approvalHeader { flex-direction: column; align-items: flex-start; gap: 4px; }
+  .approvalMeta { margin-top: 4px; }
+}
+.approvalDetails { margin: 8px 0; }
+.approvalArgs { margin-top: 6px; padding: 8px; background: #fff; border-radius: 6px; border: 1px solid #e2e2e2; }
+.approvalActions { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+.approvalActions form { display: flex; flex-direction: column; gap: 8px; }
+.approvalActions .buttons { display: inline-flex; gap: 8px; }
+
 .codeMessage {
   padding: 10px 16px;
   background-color: #e9e9e9;

--- a/templates/components/assistant-run.html
+++ b/templates/components/assistant-run.html
@@ -1,8 +1,8 @@
 <!-- assistant-run.html -->
 <div class="assistant-run" hx-target="find .dots" hx-swap="beforebegin" 
      hx-ext="sse"     
-     sse-connect="{{ url_for('stream_response', conversation_id=conversation_id) }}" 
-     sse-swap="messageCreated,toolCallCreated,toolOutput,imageOutput,fileOutput,textDelta,toolDelta,textReplacement,runCompleted,networkError"
+     sse-connect="{{ url_for('stream_response', conversation_id=conversation_id) }}{% if sse_params %}?{{ sse_params }}{% endif %}" 
+     sse-swap="messageCreated,toolCallCreated,toolOutput,mcpApprovalRequest,imageOutput,fileOutput,textDelta,toolDelta,textReplacement,runCompleted,networkError"
      hx-on:htmx:sse-before-message="handleCustomSseEvents(event)"
      sse-close="endStream"
      hx-on::sse-close="reEnableSendButton()"

--- a/templates/components/assistant-step.html
+++ b/templates/components/assistant-step.html
@@ -1,8 +1,2 @@
 <!-- assistant-step.html -->
-<div class="{{ step_type }}" id="step-{{ step_id }}">
-  {% if content_html %}
-    {{ content_html | safe }}
-  {% else %}
-    {{ content if content else "" }}
-  {% endif %}
-</div>
+<div class="{{ step_type }}" id="step-{{ step_id }}">{% if content_html %}{{ content_html | safe }}{% else %}{{ content if content else "" }}{% endif %}</div>

--- a/templates/components/assistant-step.html
+++ b/templates/components/assistant-step.html
@@ -1,2 +1,8 @@
 <!-- assistant-step.html -->
-<div class="{{ step_type }}" id="step-{{ step_id }}">{{ content if content else "" }}</div>
+<div class="{{ step_type }}" id="step-{{ step_id }}">
+  {% if content_html %}
+    {{ content_html | safe }}
+  {% else %}
+    {{ content if content else "" }}
+  {% endif %}
+</div>

--- a/templates/components/mcp-approval-request.html
+++ b/templates/components/mcp-approval-request.html
@@ -17,9 +17,11 @@
       hx-post="/chat/{{ conversation_id }}/approve"
       hx-target="#messages"
       hx-swap="beforeend"
-      onsubmit="Array.from(this.querySelectorAll('button')).forEach(b=>{ if(b!==event.submitter){ b.disabled=true }})"
+      hx-sync="this:queue"
+      onsubmit="this.querySelector('input[name=approve]').value = (event.submitter && event.submitter.value) || ''; Array.from(this.querySelectorAll('button')).forEach(b=>{ b.disabled=true })"
     >
       <input type="hidden" name="approval_request_id" value="{{ approval_request.id }}" />
+      <input type="hidden" name="approve" id="approve-{{ approval_request.id }}" />
       <label for="approvalReason-{{ approval_request.id }}">Reason (optional)</label>
       <textarea id="approvalReason-{{ approval_request.id }}" name="reason" rows="2" placeholder="Why approve or reject? (optional)"></textarea>
       <div class="buttons">

--- a/templates/components/mcp-approval-request.html
+++ b/templates/components/mcp-approval-request.html
@@ -1,0 +1,33 @@
+<!-- mcp-approval-request.html -->
+<div class="approvalCard">
+  <div class="approvalHeader">
+    <strong>Tool requires approval</strong>
+    <div class="approvalMeta">
+      <span>Server:</span> <code>{{ approval_request.server_label }}</code>
+      <span>Tool:</span> <code>{{ approval_request.name }}</code>
+    </div>
+  </div>
+  <details class="approvalDetails">
+    <summary>View call arguments</summary>
+    <pre class="approvalArgs">{{ arguments_pretty }}</pre>
+  </details>
+
+  <div class="approvalActions">
+    <form
+      hx-post="/chat/{{ conversation_id }}/approve"
+      hx-target="#messages"
+      hx-swap="beforeend"
+      onsubmit="Array.from(this.querySelectorAll('button')).forEach(b=>{ if(b!==event.submitter){ b.disabled=true }})"
+    >
+      <input type="hidden" name="approval_request_id" value="{{ approval_request.id }}" />
+      <label for="approvalReason-{{ approval_request.id }}">Reason (optional)</label>
+      <textarea id="approvalReason-{{ approval_request.id }}" name="reason" rows="2" placeholder="Why approve or reject? (optional)"></textarea>
+      <div class="buttons">
+        <button type="submit" class="button" name="approve" value="true">Approve</button>
+        <button type="submit" class="button danger" name="approve" value="false">Reject</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+

--- a/templates/components/mcp-row.html
+++ b/templates/components/mcp-row.html
@@ -22,7 +22,18 @@
       <button type="button" class="button" hx-delete="{{ url_for('delete_mcp_row') }}" hx-target="closest .mcp-row" hx-swap="outerHTML" aria-label="Remove row">✕</button>
     </div>
   </div>
-  <input type="hidden" name="mcp_require_approvals" value="never">
+  <div>
+    <label for="mcp-require-approval-{{ index }}">
+      <input
+        type="checkbox"
+        id="mcp-require-approval-{{ index }}"
+        {% if require_approval|default('never') == 'always' %}checked{% endif %}
+        onchange="this.closest('.mcp-row').querySelector('input[name=&quot;mcp_require_approvals&quot;]').value = this.checked ? 'always' : 'never';"
+      >
+      Require approval for tool calls
+    </label>
+  </div>
+  <input type="hidden" name="mcp_require_approvals" value="{% if require_approval|default('never') == 'always' %}always{% else %}never{% endif %}">
 </div>
 
 

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -158,10 +158,12 @@
                           {% set connector_id = srv.connector_id if 'connector_id' in srv else '' %}
                           {% set authorization = srv.authorization if 'authorization' in srv else '' %}
                           {% set headers_json = srv.headers_json if 'headers_json' in srv else '' %}
+                          {% set require_approval = srv.require_approval if 'require_approval' in srv else 'never' %}
                           {% include 'components/mcp-row.html' %}
                         {% endfor %}
                       {% else %}
                         {% set index = 0 %}
+                        {% set require_approval = 'never' %}
                         {% include 'components/mcp-row.html' %}
                       {% endif %}
                     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -243,7 +243,7 @@ wheels = [
 
 [[package]]
 name = "openai-responses-python-quickstart"
-version = "1.3.0"
+version = "1.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
- Checkbox on the setup page to control whether to require approval of MCP tool calls
- If approval is enabled, we handle MCP tool call requests by rendering a user approve/deny widget
- A new route handles submitting the approval/denial and resuming the conversation